### PR TITLE
[M2-FE] Implement JWT Authentication Flow on Client

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from "react-router";
+import { Routes, Route, Navigate } from "react-router";
 
 import Sidebar from "./components/Sidebar";
 
@@ -14,6 +14,17 @@ import Register from "./pages/Register";
 
 import "./App.css";
 
+function isAuthenticated() {
+  return Boolean(localStorage.getItem("token"));
+}
+
+function ProtectedLayout({ children }) {
+  if (!isAuthenticated()) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+}
+
 function App() {
   return (
     <Routes>
@@ -25,21 +36,23 @@ function App() {
       <Route
         path="*"
         element={
-          <div className="app-layout">
-            <Sidebar />
+          <ProtectedLayout>
+            <div className="app-layout">
+              <Sidebar />
 
-            <div className="main-content">
-              <Routes>
-                <Route path="/" element={<Dashboard />} />
-                <Route path="/boards" element={<BoardPage />} />
-                <Route path="/recent" element={<Recent />} />
-                <Route path="/assigned" element={<AssignedToMe />} />
-                <Route path="/team" element={<Team />} />
-                <Route path="/activity" element={<Activity />} />
-                <Route path="/settings" element={<Settings />} />
-              </Routes>
+              <div className="main-content">
+                <Routes>
+                  <Route path="/" element={<Dashboard />} />
+                  <Route path="/boards" element={<BoardPage />} />
+                  <Route path="/recent" element={<Recent />} />
+                  <Route path="/assigned" element={<AssignedToMe />} />
+                  <Route path="/team" element={<Team />} />
+                  <Route path="/activity" element={<Activity />} />
+                  <Route path="/settings" element={<Settings />} />
+                </Routes>
+              </div>
             </div>
-          </div>
+          </ProtectedLayout>
         }
       />
     </Routes>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,8 +1,46 @@
-import { Link } from "react-router";
+import { useState } from "react";
+import { Link, useNavigate } from "react-router";
 import logo from "../assets/collabboard-logo.jpeg";
 import heroImage from "../assets/hero.png";
 
+const API_BASE = "http://localhost:5000/api/v1";
+
 function Login() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      const res = await fetch(`${API_BASE}/auth/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.message || "Login failed");
+      }
+
+      localStorage.setItem("token", data.token);
+      localStorage.setItem("user", JSON.stringify(data.user));
+
+      navigate("/");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <div className="login-page">
       <section className="login-visual">
@@ -46,7 +84,9 @@ function Login() {
             Sign in to your CollabBoard workspace.
           </p>
 
-          <form className="login-form">
+          <form className="login-form" onSubmit={handleSubmit}>
+            {error && <p className="error-message">{error}</p>}
+
             <div className="auth-form-group">
               <label htmlFor="login-email">WORK EMAIL</label>
 
@@ -56,6 +96,9 @@ function Login() {
                   id="login-email"
                   type="email"
                   placeholder="name@company.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
                 />
               </div>
             </div>
@@ -72,6 +115,9 @@ function Login() {
                   id="login-password"
                   type="password"
                   placeholder="••••••••"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
                 />
                 <span className="password-eye">◉</span>
               </div>
@@ -82,8 +128,8 @@ function Login() {
               <span>Keep me signed in</span>
             </label>
 
-            <button type="submit" className="signin-btn">
-              Sign In <span>→</span>
+            <button type="submit" className="signin-btn" disabled={loading}>
+              {loading ? "Signing in..." : "Sign In"} <span>→</span>
             </button>
 
             <div className="auth-divider">

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,7 +1,53 @@
-import { Link } from "react-router";
+import { useState } from "react";
+import { Link, useNavigate } from "react-router";
 import logo from "../assets/collabboard-logo.jpeg";
 
+const API_BASE = "http://localhost:5000/api/v1";
+
 function Register() {
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError("Passwords don't match");
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const res = await fetch(`${API_BASE}/auth/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, password }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.message || "Registration failed");
+      }
+
+      localStorage.setItem("token", data.token);
+      localStorage.setItem("user", JSON.stringify(data.user));
+
+      navigate("/");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <div className="register-page">
       <div className="register-card">
@@ -16,7 +62,9 @@ function Register() {
           Join CollabBoard and start collaborating.
         </p>
 
-        <form className="register-form">
+        <form className="register-form" onSubmit={handleSubmit}>
+          {error && <p className="error-message">{error}</p>}
+
           <div className="register-form-group">
             <label htmlFor="register-name">Full Name</label>
 
@@ -26,6 +74,9 @@ function Register() {
                 id="register-name"
                 type="text"
                 placeholder="Jane Doe"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
               />
             </div>
           </div>
@@ -39,6 +90,9 @@ function Register() {
                 id="register-email"
                 type="email"
                 placeholder="jane@company.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
               />
             </div>
           </div>
@@ -52,6 +106,9 @@ function Register() {
                 id="register-password"
                 type="password"
                 placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
               />
             </div>
 
@@ -76,12 +133,15 @@ function Register() {
                 id="confirm-password"
                 type="password"
                 placeholder="••••••••"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
               />
             </div>
           </div>
 
-          <button type="submit" className="create-account-btn">
-            Create Account
+          <button type="submit" className="create-account-btn" disabled={loading}>
+            {loading ? "Creating account..." : "Create Account"}
           </button>
 
           <p className="signin-account-text">


### PR DESCRIPTION


- Wired Login.jsx and Register.jsx to real /api/v1/auth endpoints
- Token + user stored in localStorage on successful login/register
- Added ProtectedLayout in App.jsx — unauthenticated users are 
  redirected to /login when accessing any workspace route

Tested manually:
- Register → redirects into dashboard, token appears in localStorage
- Refresh while logged in → stays on dashboard (correct, token persists)
- Clear localStorage → refresh → redirected to /login correctly

Note: backend currently returns a placeholder token string pending 
#7 (real signed JWT) — client code doesn't need to change once that lands.