### PR TITLE
[M3-FE] Implement Client-Side Offline Caching

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2720,3 +2720,17 @@ button {
     font-size: 26px;
   }
 }
+
+/* =========================================
+   OFFLINE MODE
+========================================= */
+.offline-banner {
+  width: 100%;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  border-radius: 8px;
+  background: #fff3cd;
+  color: #664d03;
+  border: 1px solid #ffecb5;
+  font-weight: 600;
+}

--- a/src/pages/BoardPage.jsx
+++ b/src/pages/BoardPage.jsx
@@ -4,10 +4,13 @@ import Topbar from "../components/Topbar";
 import Board from "../components/Board";
 import apiClient from "../API/client";
 
+const CACHE_KEY = "collabboard_board";
+
 function BoardPage() {
   const [board, setBoard] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [isOffline, setIsOffline] = useState(false);
 
   const fetchBoard = async () => {
     try {
@@ -20,10 +23,21 @@ function BoardPage() {
       }
 
       const boardRes = await apiClient.get(`/boards/${activeBoard.id}`);
-      setBoard(boardRes.data);
+      const fetchedBoard = boardRes.data;
+
+      setBoard(fetchedBoard);
+      localStorage.setItem(CACHE_KEY, JSON.stringify(fetchedBoard));
     } catch (err) {
       console.error("Failed to fetch board data:", err);
+
+      const cachedBoard = localStorage.getItem(CACHE_KEY);
+
+      if (cachedBoard) {
+        setBoard(JSON.parse(cachedBoard));    
+        setIsOffline(true);
+      }else {
       setError("Unable to load board data right now.");
+      }
     } finally {
       setLoading(false);
     }
@@ -157,6 +171,11 @@ function BoardPage() {
       <Topbar title={board?.title || "Website Redesign"} />
 
       <main className="content-area">
+        {isOffline && (
+          <div className="offline-banner" role="status">
+            <p>Offline Mode - You are currently viewing offline data.</p>
+          </div>
+        )}
         {board ? (
           <Board
             board={board}


### PR DESCRIPTION
## Summary
- Added client-side board caching using localStorage
- Added fallback to cached board data when API requests fail
- Added Offline Mode banner when cached data is being viewed

## Related Issue
Closes #32