### PR TITLE
implement concurrent edit conflict UI (Resolves #33)

### DIFF
--- a/src/API/client.js
+++ b/src/API/client.js
@@ -27,6 +27,9 @@ apiClient.interceptors.request.use(
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
+    if (error.response && error.response.status === 409) {
+      window.dispatchEvent(new CustomEvent('api-conflict'));
+    }
     console.error("API request failed:", error);
     return Promise.reject(error);
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from "react-router";
 
 import Sidebar from "./components/Sidebar";
+import ConflictModal from "./components/ConflictModal";
 
 import Dashboard from "./pages/Dashboard";
 import BoardPage from "./pages/BoardPage";
@@ -39,6 +40,7 @@ function App() {
           <ProtectedLayout>
             <div className="app-layout">
               <Sidebar />
+              <ConflictModal />
 
               <div className="main-content">
                 <Routes>

--- a/src/components/ConflictModal.css
+++ b/src/components/ConflictModal.css
@@ -1,0 +1,101 @@
+.conflict-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.conflict-modal-content {
+  background-color: white;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 500px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  font-family: inherit;
+}
+
+.conflict-modal-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #fef2f2; /* Light red tint for warning */
+}
+
+.conflict-modal-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #b91c1c; /* Dark red */
+  font-weight: 600;
+}
+
+.conflict-close-button {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: #6b7280;
+}
+
+.conflict-close-button:hover {
+  color: #111827;
+}
+
+.conflict-modal-body {
+  padding: 24px;
+  color: #374151;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.conflict-modal-body p {
+  margin: 0 0 12px 0;
+}
+.conflict-modal-body p:last-child {
+  margin-bottom: 0;
+}
+
+.conflict-modal-footer {
+  padding: 16px 24px;
+  border-top: 1px solid #e5e7eb;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  background-color: #f9fafb;
+}
+
+.conflict-btn-secondary {
+  padding: 8px 16px;
+  background-color: white;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  color: #374151;
+}
+
+.conflict-btn-secondary:hover {
+  background-color: #f3f4f6;
+}
+
+.conflict-btn-primary {
+  padding: 8px 16px;
+  background-color: #ef4444; /* Red button for conflict action */
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.conflict-btn-primary:hover {
+  background-color: #dc2626;
+}

--- a/src/components/ConflictModal.jsx
+++ b/src/components/ConflictModal.jsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import "./ConflictModal.css";
+
+export default function ConflictModal() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const handleConflict = () => {
+      setIsOpen(true);
+    };
+
+    window.addEventListener("api-conflict", handleConflict);
+
+    return () => {
+      window.removeEventListener("api-conflict", handleConflict);
+    };
+  }, []);
+
+  if (!isOpen) return null;
+
+  const handleRefresh = () => {
+    window.location.reload();
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="conflict-modal-overlay">
+      <div className="conflict-modal-content">
+        <div className="conflict-modal-header">
+          <h3>Update Conflict Detected</h3>
+          <button className="conflict-close-button" onClick={handleClose}>
+            &times;
+          </button>
+        </div>
+        <div className="conflict-modal-body">
+          <p>
+            Someone else modified this board while you were viewing it. Your
+            recent changes could not be saved to prevent overwriting their work.
+          </p>
+          <p>
+            Please refresh the data to see the latest changes and try again.
+          </p>
+        </div>
+        <div className="conflict-modal-footer">
+          <button className="conflict-btn-secondary" onClick={handleClose}>
+            Cancel
+          </button>
+          <button className="conflict-btn-primary" onClick={handleRefresh}>
+            Refresh Data
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
#33 

Changes Made:
- Axios Interceptor: Updated `src/API/client.js` to intercept `409 Conflict` HTTP errors and dispatch a global `api-conflict` event.
- Conflict UI: Created a new `ConflictModal` component (with styling) that listens for the `api-conflict` event and displays a warning overlay.
- Global Integration:  Added the modal to `App.jsx` inside the `ProtectedLayout` so it is globally available without complex state management.
- Refresh Action: Added a "Refresh Data" button on the modal that triggers a page reload to pull the latest board data.

How to Test (Frontend UI):
1. Open the app in your browser and log in.
2. Open the browser Developer Tools (F12) and go to the Console.
3. Paste and run the following command to simulate the backend throwing a 409 error:

   window.dispatchEvent(new CustomEvent('api-conflict'));

4. The modal should appear. Verify that clicking "Cancel" closes it, and clicking "Refresh Data" reloads the page.